### PR TITLE
Support additional, arbitrary SQLJ args

### DIFF
--- a/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
+++ b/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
@@ -63,6 +63,12 @@ public class SqljMojo
      */
     @Parameter( property = "sqlj.sqljDirectories" )
     private File[] sqljDirs;
+    
+    /**
+     * Additional arguments to pass to the SQLJ translator.
+     */
+    @Parameter ( property = "sqlj.additionalArgs")
+    private List<String> additionalArgs;
 
     /**
      * The enclosing project.
@@ -285,6 +291,7 @@ public class SqljMojo
         }
         sqljArgs.add( "-compile=false" );
         sqljArgs.add( file.getAbsolutePath() );
+        sqljArgs.addAll(additionalArgs);
 
         Integer returnCode = null;
         try


### PR DESCRIPTION
Supporting "additional arguments" allows a consumer to pass arbitrary arguments onto the SQLJ translator.  This is useful in cases where a SQLJ translator implementation may support custom flags (e.g. https://docs.oracle.com/cd/B28359_01/java.111/b31227/transopt.htm#i1007494)
