### PR TITLE
Recovering SQLJ version in Oracle's translator.jar

### DIFF
--- a/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
+++ b/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
@@ -2,7 +2,8 @@ package org.codehaus.mojo.sqlj;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Method;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -399,18 +400,26 @@ public class SqljMojo
 
     private String getSqljVersionInfo( ClassLoader classLoader )
     {
-        String version;
-        try
+        try 
         {
-            Class<?> sqljClass = classLoader.loadClass( SQLJ_CLASS );
-            Method method = sqljClass.getDeclaredMethod("getVersion");
-            method.setAccessible(true);
-            version = (String) method.invoke(sqljClass);
+        	Class<?> sqljClass = classLoader.loadClass( SQLJ_CLASS );
+        	String version = null;
+	        try
+	        {
+	            version = (String) MethodUtils.invokeExactStaticMethod( sqljClass, "getVersion", null );
+	        }
+	        catch ( NoSuchMethodException e ) 
+	        {
+        		StringWriter stringWriter = new StringWriter();
+				MethodUtils.invokeExactStaticMethod( sqljClass, "printVersion", new PrintWriter( stringWriter ) );
+				version = stringWriter.toString();
+	        }
+	        return version;
         }
         catch ( Exception e )
         {
-            version = null;
+        	return null;
         }
-        return version;
     }
+    
 }

--- a/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
+++ b/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
@@ -402,18 +402,18 @@ public class SqljMojo
     {
         try 
         {
-        	Class<?> sqljClass = classLoader.loadClass( SQLJ_CLASS );
-        	String version = null;
-	        try
-	        {
-	            version = (String) MethodUtils.invokeExactStaticMethod( sqljClass, "getVersion", null );
-	        }
-	        catch ( NoSuchMethodException e ) 
-	        {
-        		StringWriter stringWriter = new StringWriter();
-				MethodUtils.invokeExactStaticMethod( sqljClass, "printVersion", new PrintWriter( stringWriter ) );
-				version = stringWriter.toString();
-	        }
+            Class<?> sqljClass = classLoader.loadClass( SQLJ_CLASS );
+            String version = null;
+            try
+            {
+                version = (String) MethodUtils.invokeExactStaticMethod( sqljClass, "getVersion", null );
+            }
+            catch ( NoSuchMethodException e ) 
+            {
+                StringWriter stringWriter = new StringWriter();
+                MethodUtils.invokeExactStaticMethod( sqljClass, "printVersion", new PrintWriter( stringWriter ) );
+                version = stringWriter.toString();
+            }
 	        return version;
         }
         catch ( Exception e )

--- a/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
+++ b/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
@@ -414,11 +414,11 @@ public class SqljMojo
                 MethodUtils.invokeExactStaticMethod( sqljClass, "printVersion", new PrintWriter( stringWriter ) );
                 version = stringWriter.toString();
             }
-	        return version;
+            return version;
         }
         catch ( Exception e )
         {
-        	return null;
+            return null;
         }
     }
     

--- a/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
+++ b/src/main/java/org/codehaus/mojo/sqlj/SqljMojo.java
@@ -2,6 +2,7 @@ package org.codehaus.mojo.sqlj;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -402,7 +403,9 @@ public class SqljMojo
         try
         {
             Class<?> sqljClass = classLoader.loadClass( SQLJ_CLASS );
-            version = (String) MethodUtils.invokeExactStaticMethod( sqljClass, "getVersion", null );
+            Method method = sqljClass.getDeclaredMethod("getVersion");
+            method.setAccessible(true);
+            version = (String) method.invoke(sqljClass);
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
Hi!

Using Oracle's translator.jar, i'm catching a NoSuchMethodException for sqlj.tools.Sqlj#getVersion() method. This is because sqlj.tools.Sqlj#getVersion() is private.

There's a public method to get sqlj's version, i'm calling it if sqlj.tools.Sqlj#getVersion() fails.

Thanks!
